### PR TITLE
feat(repository): implement contact repository with tests

### DIFF
--- a/backend/src/infrastructure/persistence/prisma/repositories/ContactRepository.ts
+++ b/backend/src/infrastructure/persistence/prisma/repositories/ContactRepository.ts
@@ -1,0 +1,172 @@
+import { Contact } from '../../../../domain/entities/Contact';
+import {
+  IContactRepository,
+  ContactSearchCriteria,
+} from '../../../../domain/ports/IContactRepository';
+import { SearchResult } from '../../../../domain/ports/IBaseRepository';
+import { prisma } from '../client';
+import { Address } from '../../../../domain/value-objects/Address';
+import { ProfilePicture } from '../../../../domain/value-objects/ProfilePicture';
+import { Email } from '../../../../domain/value-objects/Email';
+import { PhoneNumber } from '../../../../domain/value-objects/PhoneNumber';
+
+type PrismaContact = {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  phone: string;
+  placeId: string | null;
+  formattedAddress: string | null;
+  profilePicture: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export class PrismaContactRepository implements IContactRepository {
+  async findById(id: string): Promise<Contact | null> {
+    try {
+      const contact = await prisma.contact.findUnique({
+        where: { id },
+      });
+
+      return contact ? this.mapToEntity(contact) : null;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findByUserId(userId: string): Promise<Contact[]> {
+    try {
+      const contacts = await prisma.contact.findMany({
+        where: { userId },
+      });
+
+      return contacts.map((contact: PrismaContact) => this.mapToEntity(contact));
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async save(contact: Contact): Promise<Contact> {
+    try {
+      const data = {
+        id: contact.id,
+        userId: contact.getUserId(),
+        name: contact.getName(),
+        email: contact.getEmail(),
+        phone: contact.getPhone(),
+        placeId: contact.getAddress()?.getPlaceId() || null,
+        formattedAddress: contact.getAddress()?.getFormattedAddress() || null,
+        profilePicture: contact.getProfilePicture()?.getUrl() || null,
+      };
+
+      const saved = await prisma.contact.upsert({
+        where: { id: contact.id },
+        update: data,
+        create: data,
+      });
+
+      return this.mapToEntity(saved);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findAll(criteria: ContactSearchCriteria): Promise<SearchResult<Contact>> {
+    try {
+      const { userId, query, page = 1, limit = 10 } = criteria;
+      const validPage = Math.max(1, page);
+      const validLimit = Math.max(1, Math.min(100, limit));
+      const skip = (validPage - 1) * validLimit;
+
+      const where = {
+        userId,
+        ...(query && {
+          OR: [
+            { name: { contains: query, mode: 'insensitive' as const } },
+            { email: { contains: query.toLowerCase(), mode: 'insensitive' as const } },
+            { phone: { contains: query.replace(/\s+/g, ''), mode: 'insensitive' as const } },
+          ],
+        }),
+      };
+
+      const [contacts, total] = await Promise.all([
+        prisma.contact.findMany({
+          where,
+          skip,
+          take: validLimit,
+          orderBy: { name: 'asc' },
+        }),
+        prisma.contact.count({ where }),
+      ]);
+
+      return {
+        items: contacts.map((contact: PrismaContact) => this.mapToEntity(contact)),
+        total,
+        page: validPage,
+        limit: validLimit,
+      };
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await prisma.contact.delete({
+        where: { id },
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async count(criteria: ContactSearchCriteria): Promise<number> {
+    try {
+      const { userId, query } = criteria;
+      const where = {
+        userId,
+        ...(query && {
+          OR: [
+            { name: { contains: query, mode: 'insensitive' as const } },
+            { email: { contains: query.toLowerCase(), mode: 'insensitive' as const } },
+            { phone: { contains: query.replace(/\s+/g, ''), mode: 'insensitive' as const } },
+          ],
+        }),
+      };
+
+      return prisma.contact.count({ where });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  private mapToEntity(data: PrismaContact): Contact {
+    if (!data) {
+      throw new Error('Cannot map null or undefined data to Contact entity');
+    }
+
+    const address =
+      data.placeId && data.formattedAddress
+        ? Address.create({
+            placeId: data.placeId,
+            formattedAddress: data.formattedAddress,
+          })
+        : undefined;
+
+    const profilePicture = data.profilePicture
+      ? ProfilePicture.create({ filename: data.profilePicture })
+      : undefined;
+
+    return Contact.create({
+      id: data.id,
+      userId: data.userId,
+      name: data.name,
+      email: data.email,
+      phone: data.phone,
+      address,
+      profilePicture,
+    });
+  }
+}

--- a/backend/src/infrastructure/persistence/prisma/repositories/__tests__/ContactRepository.test.ts
+++ b/backend/src/infrastructure/persistence/prisma/repositories/__tests__/ContactRepository.test.ts
@@ -1,0 +1,188 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended';
+import { PrismaContactRepository } from '../ContactRepository';
+import { Contact } from '../../../../../domain/entities/Contact';
+import { Address } from '../../../../../domain/value-objects/Address';
+import { ProfilePicture } from '../../../../../domain/value-objects/ProfilePicture';
+
+jest.mock('../../client', () => ({
+  prisma: mockDeep<PrismaClient>(),
+}));
+
+const prismaMock = jest.requireMock('../../client').prisma as DeepMockProxy<PrismaClient>;
+
+describe('PrismaContactRepository', () => {
+  let repository: PrismaContactRepository;
+  const testContact = {
+    id: '123',
+    userId: 'user123',
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '+1234567890',
+    placeId: 'place123',
+    formattedAddress: '123 Main St',
+    profilePicture: 'profile.jpg',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    mockReset(prismaMock);
+    repository = new PrismaContactRepository();
+  });
+
+  describe('findById', () => {
+    it('should return null when contact not found', async () => {
+      prismaMock.contact.findUnique.mockResolvedValue(null);
+      const result = await repository.findById('123');
+      expect(result).toBeNull();
+    });
+
+    it('should return contact when found', async () => {
+      prismaMock.contact.findUnique.mockResolvedValue(testContact);
+      const result = await repository.findById('123');
+      expect(result).toBeInstanceOf(Contact);
+      expect(result?.id).toBe('123');
+      expect(result?.getName()).toBe('John Doe');
+      expect(result?.getEmail()).toBe('john@example.com');
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('should return empty array when no contacts found', async () => {
+      prismaMock.contact.findMany.mockResolvedValue([]);
+      const result = await repository.findByUserId('user123');
+      expect(result).toEqual([]);
+    });
+
+    it('should return contacts when found', async () => {
+      prismaMock.contact.findMany.mockResolvedValue([testContact]);
+      const result = await repository.findByUserId('user123');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(Contact);
+      expect(result[0].getUserId()).toBe('user123');
+    });
+  });
+
+  describe('save', () => {
+    it('should create new contact', async () => {
+      const contact = Contact.create({
+        userId: 'user123',
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+      });
+
+      prismaMock.contact.upsert.mockResolvedValue({
+        ...testContact,
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+      });
+
+      const result = await repository.save(contact);
+      expect(result).toBeInstanceOf(Contact);
+      expect(result.getName()).toBe('Jane Doe');
+      expect(result.getEmail()).toBe('jane@example.com');
+    });
+
+    it('should update existing contact with address and profile picture', async () => {
+      const address = Address.create({
+        placeId: 'place123',
+        formattedAddress: '123 Main St',
+      });
+
+      const profilePicture = ProfilePicture.create({
+        filename: 'profile.jpg',
+      });
+
+      const contact = Contact.create({
+        id: '123',
+        userId: 'user123',
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        phone: '+1111111111',
+        address,
+        profilePicture,
+      });
+
+      prismaMock.contact.upsert.mockResolvedValue({
+        ...testContact,
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        phone: '+1111111111',
+        placeId: 'place123',
+        formattedAddress: '123 Main St',
+        profilePicture: 'profile.jpg',
+      });
+
+      const result = await repository.save(contact);
+      expect(result).toBeInstanceOf(Contact);
+      expect(result.getName()).toBe('Updated Name');
+      expect(result.getEmail()).toBe('updated@example.com');
+      expect(result.getAddress()?.getPlaceId()).toBe('place123');
+      expect(result.getProfilePicture()?.getUrl()).toBe('/uploads/profile-pictures/profile.jpg');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      const contacts = [testContact];
+      prismaMock.contact.findMany.mockResolvedValue(contacts);
+      prismaMock.contact.count.mockResolvedValue(1);
+
+      const result = await repository.findAll({ userId: 'user123', page: 1, limit: 10 });
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(10);
+    });
+
+    it('should filter by search query', async () => {
+      const contacts = [testContact];
+      prismaMock.contact.findMany.mockResolvedValue(contacts);
+      prismaMock.contact.count.mockResolvedValue(1);
+
+      await repository.findAll({ userId: 'user123', query: 'john' });
+      expect(prismaMock.contact.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: 'user123',
+            OR: [
+              { name: { contains: 'john', mode: 'insensitive' } },
+              { email: { contains: 'john', mode: 'insensitive' } },
+              { phone: { contains: 'john', mode: 'insensitive' } },
+            ],
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete contact', async () => {
+      await repository.delete('123');
+      expect(prismaMock.contact.delete).toHaveBeenCalledWith({
+        where: { id: '123' },
+      });
+    });
+  });
+
+  describe('count', () => {
+    it('should count contacts with search criteria', async () => {
+      prismaMock.contact.count.mockResolvedValue(5);
+      const count = await repository.count({ userId: 'user123', query: 'john' });
+      expect(count).toBe(5);
+      expect(prismaMock.contact.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          userId: 'user123',
+          OR: [
+            { name: { contains: 'john', mode: 'insensitive' } },
+            { email: { contains: 'john', mode: 'insensitive' } },
+            { phone: { contains: 'john', mode: 'insensitive' } },
+          ],
+        }),
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Contact Repository Implementation

## Description
Implement the Contact repository using Prisma ORM, including comprehensive test coverage.

## Changes
- Add PrismaContactRepository implementation with all CRUD operations
- Add full test coverage using jest-mock-extended
- Implement proper mapping between Prisma models and domain entities
- Add support for search, pagination, and filtering
