### PR TITLE
feat(auth): implement authentication interface layer

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,17 +1,32 @@
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import { createAuthRouter } from './interfaces/http/routes/auth.routes';
+import { AuthenticationService } from './application/services/AuthenticationService';
+import { PrismaUserRepository } from './infrastructure/persistence/prisma/repositories/UserRepository';
+import { BcryptPasswordService } from './infrastructure/auth/services/BcryptPasswordService';
+import { JwtTokenService } from './infrastructure/auth/services/JwtTokenService';
 
 dotenv.config();
 
 const app = express();
 
+// Initialize dependencies
+const userRepository = new PrismaUserRepository();
+const passwordService = new BcryptPasswordService();
+const tokenService = new JwtTokenService(process.env.JWT_SECRET || 'your-secret-key');
+const authService = new AuthenticationService(userRepository, passwordService, tokenService);
+
+// Middleware
 app.use(cors());
 app.use(express.json());
 
+// Routes
 app.get('/health', (_req: Request, res: Response): void => {
   res.json({ status: 'ok' });
 });
+
+app.use('/api', createAuthRouter(authService));
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/src/interfaces/http/controllers/AuthController.ts
+++ b/backend/src/interfaces/http/controllers/AuthController.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import { IAuthenticationService } from '../../../application/ports/IAuthenticationService';
+
+export class AuthController {
+  constructor(private readonly authService: IAuthenticationService) {}
+
+  login = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { email, password } = req.body;
+
+      if (!email || !password) {
+        res.status(400).json({ message: 'Email and password are required' });
+        return;
+      }
+
+      const result = await this.authService.authenticate(email, password);
+
+      res.status(200).json({
+        token: result.token,
+        user: result.user,
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Invalid email or password') {
+          res.status(401).json({ message: error.message });
+          return;
+        }
+      }
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  };
+
+  getCurrentUser = async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!req.user) {
+        res.status(401).json({ message: 'User not authenticated' });
+        return;
+      }
+
+      const response = { user: req.user };
+      res.status(200).json(response);
+    } catch (error) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  };
+}

--- a/backend/src/interfaces/http/controllers/__tests__/AuthController.test.ts
+++ b/backend/src/interfaces/http/controllers/__tests__/AuthController.test.ts
@@ -1,0 +1,169 @@
+import { Request, Response } from 'express';
+import { AuthController } from '../AuthController';
+import { IAuthenticationService } from '../../../../application/ports/IAuthenticationService';
+import { User } from '../../../../domain/entities/User';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let mockAuthService: jest.Mocked<IAuthenticationService>;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  const testUser = User.create({
+    id: 'user123',
+    email: 'test@example.com',
+    password: 'hashedPassword',
+  });
+
+  beforeEach(() => {
+    mockAuthService = {
+      authenticate: jest.fn(),
+      verifyToken: jest.fn(),
+      generateToken: jest.fn(),
+    };
+
+    mockRequest = {
+      body: {},
+    };
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    controller = new AuthController(mockAuthService);
+  });
+
+  describe('login', () => {
+    it('should authenticate user and return token', async () => {
+      const testToken = 'valid.jwt.token';
+      mockRequest.body = {
+        email: 'test@example.com',
+        password: 'password123',
+      };
+
+      mockAuthService.authenticate.mockResolvedValue({
+        user: testUser,
+        token: testToken,
+      });
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockAuthService.authenticate).toHaveBeenCalledWith('test@example.com', 'password123');
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        user: testUser,
+        token: testToken,
+      });
+    });
+
+    it('should return 400 when email is missing', async () => {
+      mockRequest.body = {
+        password: 'password123',
+      };
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Email and password are required',
+      });
+    });
+
+    it('should return 400 when password is missing', async () => {
+      mockRequest.body = {
+        email: 'test@example.com',
+      };
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Email and password are required',
+      });
+    });
+
+    it('should return 401 for invalid credentials', async () => {
+      mockRequest.body = {
+        email: 'test@example.com',
+        password: 'wrongpassword',
+      };
+
+      mockAuthService.authenticate.mockRejectedValue(new Error('Invalid email or password'));
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Invalid email or password',
+      });
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+      mockRequest.body = {
+        email: 'test@example.com',
+        password: 'password123',
+      };
+
+      mockAuthService.authenticate.mockRejectedValue(new Error('Unexpected error'));
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    it('should return the authenticated user', async () => {
+      mockRequest.user = testUser;
+
+      await controller.getCurrentUser(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        user: testUser,
+      });
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      mockRequest.user = undefined;
+
+      await controller.getCurrentUser(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'User not authenticated',
+      });
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+      mockRequest.user = testUser;
+      let statusCalled = false;
+      let jsonCalled = false;
+
+      mockResponse.status = jest.fn().mockImplementation((code: number) => {
+        statusCalled = true;
+        if (code === 200) {
+          throw new Error('Unexpected error');
+        }
+        return mockResponse;
+      });
+
+      mockResponse.json = jest.fn().mockImplementation(() => {
+        jsonCalled = true;
+      });
+
+      await controller.getCurrentUser(mockRequest as Request, mockResponse as Response);
+
+      expect(statusCalled).toBe(true);
+      expect(jsonCalled).toBe(true);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+});

--- a/backend/src/interfaces/http/routes/auth.routes.ts
+++ b/backend/src/interfaces/http/routes/auth.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { AuthController } from '../controllers/AuthController';
+import { AuthMiddleware } from '../../middleware/AuthMiddleware';
+import { IAuthenticationService } from '../../../application/ports/IAuthenticationService';
+
+export const createAuthRouter = (authService: IAuthenticationService): Router => {
+  const router = Router();
+  const authController = new AuthController(authService);
+  const authMiddleware = new AuthMiddleware(authService);
+
+  router.post('/login', (req, res) => authController.login(req, res));
+  router.get('/user', authMiddleware.authenticate.bind(authMiddleware), (req, res) =>
+    authController.getCurrentUser(req, res),
+  );
+
+  return router;
+};


### PR DESCRIPTION
## Description
This PR implements the authentication interface layer, adding the authentication controller and routes.

### Changes
- Add `AuthController` with login and getCurrentUser endpoints
- Integrate with existing authentication service and middleware
- Added auth routes (`/api/login` and `/api/user`)
- Set up Express server with middleware and route configuration

### Testing Instructions
Precondition: have seeded users.

Test login endpoint with:
   ```bash
   curl -X POST http://localhost:3000/api/login \
   -H "Content-Type: application/json" \
   -d '{"email": "admin@example.com", "password": "password123"}'
   ```

Test getCurrentUser with obtained token:
   ```bash
   curl http://localhost:3000/api/user \
   -H "Authorization: Bearer <token>"
   ```